### PR TITLE
Make ConfigValueMut non-exhaustive and release v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [Unreleased]: https://github.com/trussed-dev/admin-app/compare/0.2.0...HEAD
 
 - Add support for string config fields.
+- Make `ConfigValueMut` non-exhaustive.
 
 ## [0.2.0] 2026-07-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-[Unreleased]: https://github.com/trussed-dev/admin-app/compare/0.2.0...HEAD
+[Unreleased]: https://github.com/trussed-dev/admin-app/compare/0.3.0...HEAD
+
+-
+
+## [0.3.0] 2026-08-17
+
+[0.3.0]: https://github.com/trussed-dev/admin-app/compare/0.2.0...0.3.0
 
 - Add support for string config fields.
 - Make `ConfigValueMut` non-exhaustive.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "admin-app"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Conor Patrick <conor@solokeys.com>", "Nicolas Stalder <nicolas@solokeys.com>"]
 repository = "https://github.com/solokeys/admin-app"
 edition = "2021"

--- a/src/config.rs
+++ b/src/config.rs
@@ -229,6 +229,7 @@ impl Config for () {
 }
 
 #[derive(Debug, Serialize)]
+#[non_exhaustive]
 pub enum ConfigValueMut<'a> {
     Bool(&'a mut bool),
     U8(&'a mut u8),


### PR DESCRIPTION
This makes it possible to add new field types without a breaking
release. The FieldType enum already is non-exhaustive, but we also need
to handle values of that type to make use of that.